### PR TITLE
list: Add doubly linked list module/package

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -59,6 +59,7 @@ playground. Note that not each example uses/needs `gobash`.
 * [`ring_next_ex`](/examples/playground/ring_next_ex)
 * [`ring_prev_ex`](/examples/playground/ring_prev_ex)
 * [`ring_unlink_ex`](/examples/playground/ring_unlink_ex)
+* [`list_ex`](/examples/playground/list_ex)
 
 ### Rewrites
 

--- a/examples/playground/list_ex
+++ b/examples/playground/list_ex
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Example that corresponds to https://go.dev/play/p/9JuKIGdWlpF from
+# the go documentation.
+
+readonly DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. ${DIR}/../../gobash
+
+
+function main() {
+        local l
+        l=$(container_List) || \
+                { ctx_w "cannot make a list"; return $EC; }
+
+        local e4
+        e4=$($l push_back 4) || \
+                { ctx_w "cannot push 4"; return $EC; }
+
+        local e1
+        e1=$($l push_front 1) || \
+                { ctx_w "cannot push 1"; return $EC; }
+
+        $l insert_before 3 "$e4" > /dev/null || return $EC
+        $l insert_after 2 "$e1" > /dev/null || return $EC
+
+        local e=$($l front)
+        while [ "$e" != "$NULL" ]; do
+                echo "$($e value)"
+                e=$($e next) || return $EC
+        done
+}
+
+ctx_clear
+main || ctx_show

--- a/examples/playground/playground_test.sh
+++ b/examples/playground/playground_test.sh
@@ -84,3 +84,8 @@ function test_playground_ring_unlink_ex() {
         _exet "$FUNCNAME"
 }
 readonly -f test_playground_ring_unlink_ex
+
+function test_playground_list_ex() {
+        _exet "$FUNCNAME"
+}
+readonly -f test_playground_list_ex

--- a/src/container/list.sh
+++ b/src/container/list.sh
@@ -18,6 +18,11 @@ readonly CONTAINER_LIST_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # Functions.
 
 function container_Element() {
+        # Construct an element of a list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
         make_ "$FUNCNAME" \
               "value" "$NULL" \
               "_next" "$NULL" \
@@ -26,12 +31,16 @@ function container_Element() {
 }
 
 function container_Element_next() {
-        local -r el="${1}"
+        # Get the next element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
+        local -r e="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
-        local -r l=$($el _list)
+        local -r l=$($e _list)
         is_null "$l" && echo "$NULL" && return 0
 
-        local -r p=$($el _next)
+        local -r p=$($e _next)
         local -r r=$($l _root)
         [ "$p" = "$r" ] && echo "$NULL" && return 0
 
@@ -39,12 +48,16 @@ function container_Element_next() {
 }
 
 function container_Element_prev() {
-        local -r el="${1}"
+        # Get the previous element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
+        local -r e="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
-        local -r l=$($el _list)
+        local -r l=$($e _list)
         is_null "$l" && return "$NULL"
 
-        local -r p=$($el _prev)
+        local -r p=$($e _prev)
         local -r r=$($l _root)
         [ "$p" = "$r" ] && return "$NULL"
 
@@ -52,6 +65,11 @@ function container_Element_prev() {
 }
 
 function container_List() {
+        # Construct a doubly linked list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
         local l
         l=$(make_ "$FUNCNAME" \
                   "_root" "$(container_Element)" \
@@ -61,7 +79,11 @@ function container_List() {
 }
 
 function container_List_init() {
+        # Init a list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
         local -r r=$($l _root)
         $r _next "$r"
@@ -71,13 +93,21 @@ function container_List_init() {
 }
 
 function container_List_len() {
+        # Return length of a list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
         $l _len
 }
 
 function container_List_front() {
+        # Return element at the front.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
         local -r len=$($l _len)
         [ "${len}" -eq 0 ] && echo "$NULL" && return 0
@@ -87,7 +117,11 @@ function container_List_front() {
 }
 
 function container_List_back() {
+        # Return element at the back.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
         local -r len=$($l _len)
         [ "${len}" -eq 0 ] && echo "$NULL" && return 0
@@ -97,7 +131,11 @@ function container_List_back() {
 }
 
 function _container_List_lazy_init() {
+        # Lazy init the given list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
+        shift 1 || { ctx_wn $ctx; return $EC; }
 
         if [ "$($($l _root) _next)" = "$NULL" ]; then
                 $l init
@@ -105,9 +143,13 @@ function _container_List_lazy_init() {
 }
 
 function _container_List_insert() {
+        # Insert an element at the given element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
         local -r at="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         $e _prev "$at"
         $e _next "$($at _next)"
@@ -120,9 +162,13 @@ function _container_List_insert() {
 }
 
 function _container_List_insert_value() {
+        # Insert a value at the given element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r v="${2}"
         local -r at="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         local -r e=$(container_Element)
         $e value "$v"
@@ -130,8 +176,12 @@ function _container_List_insert_value() {
 }
 
 function _container_List_remove() {
+        # Remove the given element from the list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         $($e _prev) _next "$($e _next)"
         $($e _next) _prev "$($e _prev)"
@@ -142,9 +192,13 @@ function _container_List_remove() {
 }
 
 function _container_List_move() {
+        # Move the given element to the given element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
         local -r at="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         [ "$e" = "$at" ] && return 0
 
@@ -158,8 +212,12 @@ function _container_List_move() {
 }
 
 function container_List_remove() {
+        # Remove the given element from this list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         if [ "$($e _list)" = "$l" ]; then
                 _container_List_remove "$l" "$e"
@@ -168,8 +226,12 @@ function container_List_remove() {
 }
 
 function container_List_push_front() {
+        # Push a value to the front of this list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r v="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         _container_List_lazy_init "$l"
 
@@ -178,8 +240,12 @@ function container_List_push_front() {
 }
 
 function container_List_push_back() {
+        # Push a value to the back of this list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r v="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         _container_List_lazy_init "$l"
 
@@ -188,9 +254,13 @@ function container_List_push_back() {
 }
 
 function container_List_insert_before() {
+        # Insert a value before the marker element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r v="${2}"
         local -r mark="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         [ "$($mark _list)" != "$l" ] && echo "$NULL" && return 0
 
@@ -198,9 +268,13 @@ function container_List_insert_before() {
 }
 
 function container_List_insert_after() {
+        # Insert a value after the marker element.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r v="${2}"
         local -r mark="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         [ "$($mark _list)" != "$l" ] && echo "$NULL" && return 0
 
@@ -208,16 +282,24 @@ function container_List_insert_after() {
 }
 
 function container_List_move_to_front() {
+        # Move element to the front of the list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         [ "$($e _list)" != "$l" ] && return 0
         $l move "$e" "$($l _root)"
 }
 
 function container_List_move_to_back() {
+        # Move element to the back of the list.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         [ "$($e _list)" != "$l" ] && return 0
 
@@ -225,9 +307,13 @@ function container_List_move_to_back() {
 }
 
 function container_List_move_before() {
+        # Move element before the given marker.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
         local -r mark="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         [ "$e" = "$mark" ] && return 0
         [ "$($e _list)" != "$l" ] && return 0
@@ -237,9 +323,13 @@ function container_List_move_before() {
 }
 
 function container_List_move_after() {
+        # Move element after the given marker.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 3 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r e="${2}"
         local -r mark="${3}"
+        shift 3 || { ctx_wn $ctx; return $EC; }
 
         [ "$e" = "$mark" ] && return 0
         [ "$($e _list)" != "$l" ] && return 0
@@ -249,8 +339,12 @@ function container_List_move_after() {
 }
 
 function container_List_push_back_list() {
+        # Push one list at the end of another.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r other="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         _container_List_lazy_init "$l"
 
@@ -263,8 +357,12 @@ function container_List_push_back_list() {
 }
 
 function container_List_push_front_list() {
+        # Push one list to the front of another.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
         local -r l="${1}"
         local -r other="${2}"
+        shift 2 || { ctx_wn $ctx; return $EC; }
 
         _container_List_lazy_init "$l"
 

--- a/src/container/list.sh
+++ b/src/container/list.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+#
+# https://github.com/EngineeringSoftware/gobash/blob/main/LICENSE
+#
+# Doubly linked list.
+#
+# This directly corresponds to https://pkg.go.dev/container/list
+# (src/container/list/list.go).
+
+if [ -n "${CONTAINER_LIST_MOD:-}" ]; then return 0; fi
+readonly CONTAINER_LIST_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+. ${CONTAINER_LIST_MOD}/../lang/p.sh
+. ${CONTAINER_LIST_MOD}/../util/p.sh
+
+
+# ----------
+# Functions.
+
+function container_Element() {
+        make_ "$FUNCNAME" \
+              "value" "$NULL" \
+              "_next" "$NULL" \
+              "_prev" "$NULL" \
+              "_list" "$NULL"
+}
+
+function container_Element_next() {
+        local -r el="${1}"
+
+        local -r l=$($el _list)
+        is_null "$l" && echo "$NULL" && return 0
+
+        local -r p=$($el _next)
+        local -r r=$($l _root)
+        [ "$p" = "$r" ] && echo "$NULL" && return 0
+
+        echo "$p"
+}
+
+function container_Element_prev() {
+        local -r el="${1}"
+
+        local -r l=$($el _list)
+        is_null "$l" && return "$NULL"
+
+        local -r p=$($el _prev)
+        local -r r=$($l _root)
+        [ "$p" = "$r" ] && return "$NULL"
+
+        echo "$p"
+}
+
+function container_List() {
+        local l
+        l=$(make_ "$FUNCNAME" \
+                  "_root" "$(container_Element)" \
+                  "_len" 0) || return $EC
+
+        $l init
+}
+
+function container_List_init() {
+        local -r l="${1}"
+
+        local -r r=$($l _root)
+        $r _next "$r"
+        $r _prev "$r"
+
+        echo "$l"
+}
+
+function container_List_len() {
+        local -r l="${1}"
+
+        $l _len
+}
+
+function container_List_front() {
+        local -r l="${1}"
+
+        local -r len=$($l _len)
+        [ "${len}" -eq 0 ] && echo "$NULL" && return 0
+
+        local -r r=$($l _root)
+        echo "$($r _next)"
+}
+
+function container_List_back() {
+        local -r l="${1}"
+
+        local -r len=$($l _len)
+        [ "${len}" -eq 0 ] && echo "$NULL" && return 0
+
+        local -r r=$($l _root)
+        echo "$($r _prev)"
+}
+
+function _container_List_lazy_init() {
+        local -r l="${1}"
+
+        if [ "$($($l _root) _next)" = "$NULL" ]; then
+                $l init
+        fi
+}
+
+function _container_List_insert() {
+        local -r l="${1}"
+        local -r e="${2}"
+        local -r at="${3}"
+
+        $e _prev "$at"
+        $e _next "$($at _next)"
+        $($e _prev) _next "$e"
+        $($e _next) _prev "$e"
+        $e _list "$l"
+        $l _len "$(( $($l _len) + 1 ))"
+
+        echo "$e"
+}
+
+function _container_List_insert_value() {
+        local -r l="${1}"
+        local -r v="${2}"
+        local -r at="${3}"
+
+        local -r e=$(container_Element)
+        $e value "$v"
+        _container_List_insert "$l" "$e" "$at"
+}
+
+function _container_List_remove() {
+        local -r l="${1}"
+        local -r e="${2}"
+
+        $($e _prev) _next "$($e _next)"
+        $($e _next) _prev "$($e _prev)"
+        $e _next "$NULL"
+        $e _prev "$NULL"
+        $e _list "$NULL"
+        $l _len "$(( $($l _len) - 1 ))"
+}
+
+function _container_List_move() {
+        local -r l="${1}"
+        local -r e="${2}"
+        local -r at="${3}"
+
+        [ "$e" = "$at" ] && return 0
+
+        $($e _prev) _next "$($e _next)"
+        $($e _next) _prev "$($e _prev)"
+
+        $e _prev "$at"
+        $e _next "$($at _next)"
+        $($e _prev) _next "$e"
+        $($e _next) _prev "$e"
+}
+
+function container_List_remove() {
+        local -r l="${1}"
+        local -r e="${2}"
+
+        if [ "$($e _list)" = "$l" ]; then
+                _container_List_remove "$l" "$e"
+        fi
+        echo "$($e value)"
+}
+
+function container_List_push_front() {
+        local -r l="${1}"
+        local -r v="${2}"
+
+        _container_List_lazy_init "$l"
+
+        local -r r=$($l _root)
+        _container_List_insert_value "$l" "$v" "$r"
+}
+
+function container_List_push_back() {
+        local -r l="${1}"
+        local -r v="${2}"
+
+        _container_List_lazy_init "$l"
+
+        local -r r=$($l _root)
+        _container_List_insert_value "$l" "$v" "$($r _prev)"
+}
+
+function container_List_insert_before() {
+        local -r l="${1}"
+        local -r v="${2}"
+        local -r mark="${3}"
+
+        [ "$($mark _list)" != "$l" ] && echo "$NULL" && return 0
+
+        _container_List_insert_value "$l" "$v" "$($mark _prev)"
+}
+
+function container_List_insert_after() {
+        local -r l="${1}"
+        local -r v="${2}"
+        local -r mark="${3}"
+
+        [ "$($mark _list)" != "$l" ] && echo "$NULL" && return 0
+
+        _container_List_insert_value "$l" "$v" "$mark"
+}
+
+function container_List_move_to_front() {
+        local -r l="${1}"
+        local -r e="${2}"
+
+        [ "$($e _list)" != "$l" ] && return 0
+        $l move "$e" "$($l _root)"
+}
+
+function container_List_move_to_back() {
+        local -r l="${1}"
+        local -r e="${2}"
+
+        [ "$($e _list)" != "$l" ] && return 0
+
+        $l move "$e" "$($($l _root) _prev)"
+}
+
+function container_List_move_before() {
+        local -r l="${1}"
+        local -r e="${2}"
+        local -r mark="${3}"
+
+        [ "$e" = "$mark" ] && return 0
+        [ "$($e _list)" != "$l" ] && return 0
+        [ "$($mark _list)" != "$l" ] && return 0
+
+        $l move "$e" "$($mark _prev)"
+}
+
+function container_List_move_after() {
+        local -r l="${1}"
+        local -r e="${2}"
+        local -r mark="${3}"
+
+        [ "$e" = "$mark" ] && return 0
+        [ "$($e _list)" != "$l" ] && return 0
+        [ "$($mark _list)" != "$l" ] && return 0
+
+        $l move "$e" "$mark"
+}
+
+function container_List_push_back_list() {
+        local -r l="${1}"
+        local -r other="${2}"
+
+        _container_List_lazy_init "$l"
+
+        local i=$($other _len)
+        local e=$($other front)
+        for (( ; i>0; i-- )); do
+                _container_List_insert_value "$l" "$($e value)" "$($($l _root) _prev)"
+                e=$($e next)
+        done
+}
+
+function container_List_push_front_list() {
+        local -r l="${1}"
+        local -r other="${2}"
+
+        _container_List_lazy_init "$l"
+
+        local i=$($other _len)
+        local e=$($other back)
+        for (( ; i>0; i-- )); do
+                _container_List_insert_value "$l" "$($e value)" "$($l _root)"
+                e=$($e prev)
+        done
+}

--- a/src/container/list_test.sh
+++ b/src/container/list_test.sh
@@ -101,6 +101,15 @@ function test_container_list_remove() {
 }
 readonly -f test_container_list_remove
 
+function test_container_list_remove_error() {
+        local l
+        l=$(container_List)
+        $l remove "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_remove_error
+
 function test_container_list_insert_before() {
         local l
         l=$(container_List) || assert_fail
@@ -120,6 +129,16 @@ function test_container_list_insert_before() {
         [ "${v}" = 10 ] || assert_fail
 }
 readonly -f test_container_list_insert_before
+
+function test_container_list_insert_before_error() {
+        local l
+        l=$(container_List)
+
+        $l insert_before 10 "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_insert_before_error
 
 function test_container_list_insert_after() {
         local l
@@ -141,6 +160,16 @@ function test_container_list_insert_after() {
 }
 readonly -f test_container_list_insert_after
 
+function test_container_list_insert_after_error() {
+        local l
+        l=$(container_List)
+
+        $l insert_after 10 "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_insert_after_error
+
 function test_container_list_move_to_front() {
         local l
         l=$(container_List)
@@ -160,6 +189,16 @@ function test_container_list_move_to_front() {
 }
 readonly -f test_container_list_move_to_front
 
+function test_container_list_move_to_front_error() {
+        local l
+        l=$(container_List)
+
+        $l move_to_front "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_move_to_front_error
+
 function test_container_list_move_to_back() {
         local l
         l=$(container_List)
@@ -178,6 +217,16 @@ function test_container_list_move_to_back() {
         [ "${v}" = 10 ] || assert_fail "was ${v}"
 }
 readonly -f test_container_list_move_to_back
+
+function test_container_list_move_to_back_error() {
+        local l
+        l=$(container_List)
+
+        $l move_to_back "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_move_to_back_error
 
 function test_container_list_move_before() {
         local l
@@ -205,6 +254,16 @@ function test_container_list_move_before() {
 }
 readonly -f test_container_list_move_before
 
+function test_container_list_move_before_error() {
+        local l
+        l=$(container_List)
+
+        $l move_before "$NULL" "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_move_before_error
+
 function test_container_list_move_after() {
         local l
         l=$(container_List)
@@ -230,6 +289,16 @@ function test_container_list_move_after() {
         [ "${v}" = 10 ] || assert_fail
 }
 readonly -f test_container_list_move_after
+
+function test_container_list_move_after_error() {
+        local l
+        l=$(container_List)
+
+        $l move_after "$NULL" "$NULL"
+
+        return 0
+}
+readonly -f test_container_list_move_after_error
 
 function test_container_list_push_back_list() {
         local l1
@@ -258,6 +327,16 @@ function test_container_list_push_back_list() {
 }
 readonly -f test_container_list_push_back_list
 
+function test_container_list_push_back_list_error() {
+        local l1
+        l1=$(container_List)
+
+        $l1 push_back_list "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_push_back_list_error
+
 function test_container_list_push_front_list() {
         local l1
         l1=$(container_List)
@@ -284,3 +363,13 @@ function test_container_list_push_front_list() {
         [ "${v}" -eq 3 ] || assert_fail
 }
 readonly -f test_container_list_push_front_list
+
+function test_container_list_push_front_list_error() {
+        local l1
+        l1=$(container_List)
+
+        $l1 push_front_list "$NULL" && assert_fail
+
+        return 0
+}
+readonly -f test_container_list_push_front_list_error

--- a/src/container/list_test.sh
+++ b/src/container/list_test.sh
@@ -65,3 +65,222 @@ function test_container_list_push_front() {
         [ "${v}" = 3 ] || assert_fail
 }
 readonly -f test_container_list_push_front
+
+function test_container_list_remove() {
+        local l
+        l=$(container_List)
+
+        $l push_back 3
+        $l push_back 10
+        $l push_back 55
+
+        [ "$($l len)" -eq 3 ] || assert_fail
+
+        local e
+        local v
+
+        e=$($l front)
+        $l remove "$e" || assert_fail
+        [ "$($l len)" -eq 2 ] || assert_fail
+
+        e=$($l front)
+        v=$($e value)
+        [ "${v}" -eq 10 ] || assert_fail
+
+        e=$($l back)
+        $l remove "$e" || assert_fail
+        [ "$($l len)" -eq 1 ] || assert_fail
+
+        e=$($l front)
+        v=$($e value)
+        [ "${v}" -eq 10 ] || assert_fail
+
+        e=$($l front)
+        $l remove "$e" || assert_fail
+        [ "$($l len)" -eq 0 ] || assert_fail
+}
+readonly -f test_container_list_remove
+
+function test_container_list_insert_before() {
+        local l
+        l=$(container_List) || assert_fail
+
+        $l push_back 3 || assert_fail
+
+        local e
+        local v
+
+        e=$($l front) || assert_fail
+        $l insert_before 10 "$e" || assert_fail
+
+        [ "$($l len)" -eq 2 ] || assert_fail
+
+        e=$($l front) || assert_fail
+        v=$($e value) || assert_fail
+        [ "${v}" = 10 ] || assert_fail
+}
+readonly -f test_container_list_insert_before
+
+function test_container_list_insert_after() {
+        local l
+        l=$(container_List) || assert_fail
+
+        $l push_back 3 || assert_fail
+
+        local e
+        local v
+
+        e=$($l front) || assert_fail
+        $l insert_after 10 "$e" || assert_fail
+
+        [ "$($l len)" -eq 2 ] || assert_fail
+
+        e=$($l front)
+        v=$($e value)
+        [ "${v}" = 3 ] || assert_fail
+}
+readonly -f test_container_list_insert_after
+
+function test_container_list_move_to_front() {
+        local l
+        l=$(container_List)
+
+        $l push_back 3
+        $l push_back 10
+
+        local e
+        local v
+
+        e=$($l back)
+        $l move_to_front "$e" || assert_fail
+
+        e=$($l front)
+        v=$($e value)
+        [ "${v}" = 10 ] || assert_fail "was ${v}"
+}
+readonly -f test_container_list_move_to_front
+
+function test_container_list_move_to_back() {
+        local l
+        l=$(container_List)
+
+        $l push_back 3
+        $l push_back 10
+
+        local e
+        local v
+
+        e=$($l front)
+        $l move_to_back "$e" || assert_fail
+
+        e=$($l front)
+        v=$($e value)
+        [ "${v}" = 10 ] || assert_fail "was ${v}"
+}
+readonly -f test_container_list_move_to_back
+
+function test_container_list_move_before() {
+        local l
+        l=$(container_List)
+
+        $l push_back 3
+        $l push_back 5
+        $l push_back 10
+
+        local e1
+        local e2
+        local e3
+        local v
+
+        e1=$($l front)
+        e2=$($e1 next)
+        e3=$($e2 next)
+
+        $l move_before "$e3" "$e2" || assert_fail
+        [ "$($l len)" = 3 ] || assert_fail
+
+        e2=$($e1 next)
+        v=$($e2 value)
+        [ "${v}" = 10 ] || assert_fail
+}
+readonly -f test_container_list_move_before
+
+function test_container_list_move_after() {
+        local l
+        l=$(container_List)
+
+        $l push_back 3
+        $l push_back 5
+        $l push_back 10
+
+        local e1
+        local e2
+        local e3
+        local v
+
+        e1=$($l front)
+        e2=$($e1 next)
+        e3=$($e2 next)
+
+        $l move_after "$e3" "$e1" || assert_fail
+        [ "$($l len)" = 3 ] || assert_fail
+
+        e2=$($e1 next)
+        v=$($e2 value)
+        [ "${v}" = 10 ] || assert_fail
+}
+readonly -f test_container_list_move_after
+
+function test_container_list_push_back_list() {
+        local l1
+        l1=$(container_List)
+        $l1 push_back 2
+        $l1 push_back 3
+
+        local l2
+        l2=$(container_List)
+        $l2 push_back 10
+        $l2 push_back 20
+
+        $l1 push_back_list "$l2" || assert_fail
+        [ "$($l1 len)" -eq 4 ] || assert_fail
+
+        local e
+        local v
+
+        e=$($l1 front)
+        v=$($e value)
+        [ "${v}" -eq 2 ] || assert_fail
+
+        e=$($l1 back)
+        v=$($e value)
+        [ "${v}" -eq 20 ] || assert_fail
+}
+readonly -f test_container_list_push_back_list
+
+function test_container_list_push_front_list() {
+        local l1
+        l1=$(container_List)
+        $l1 push_back 2
+        $l1 push_back 3
+
+        local l2
+        l2=$(container_List)
+        $l2 push_back 10
+        $l2 push_back 20
+
+        $l1 push_front_list "$l2" || assert_fail
+        [ "$($l1 len)" -eq 4 ] || assert_fail
+
+        local e
+        local v
+
+        e=$($l1 front)
+        v=$($e value)
+        [ "${v}" -eq 10 ] || assert_fail
+
+        e=$($l1 back)
+        v=$($e value)
+        [ "${v}" -eq 3 ] || assert_fail
+}
+readonly -f test_container_list_push_front_list

--- a/src/container/list_test.sh
+++ b/src/container/list_test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# https://github.com/EngineeringSoftware/gobash/blob/main/LICENSE
+#
+# Unit tests for the list module.
+
+if [ -n "${CONTAINER_LIST_TEST_MOD:-}" ]; then return 0; fi
+readonly CONTAINER_LIST_TEST_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+. ${CONTAINER_LIST_TEST_MOD}/list.sh
+. ${CONTAINER_LIST_TEST_MOD}/../testing/bunit.sh
+
+
+# ----------
+# Functions.
+
+function test_container_list_new() {
+        local -r l=$(container_List)
+
+        [ "$($l len)" -eq 0 ] || assert_fail
+}
+readonly -f test_container_list_new
+
+function test_container_list_push_back() {
+        local -r l=$(container_List)
+
+        $l push_back 3
+        $l push_back 4
+        $l push_back 10
+
+        [ "$($l len)" -eq 3 ] || assert_fail
+
+        local e
+        local v
+
+        e=$($l front) || assert_fail
+        v=$($e value) || assert_fail
+        [ "${v}" = "3" ] || assert_fail
+
+        e=$($l back) || assert_fail
+        v=$($e value) || assert_fail
+        [ "${v}" = 10 ] || assert_fail
+}
+readonly -f test_container_list_push_back
+
+function test_container_list_push_front() {
+        local l
+        l=$(container_List) || assert_fail
+
+        $l push_front 3
+        $l push_front 4
+        $l push_front 10
+
+        [ "$($l len)" -eq 3 ] || assert_fail
+
+        local e
+        local v
+ 
+        e=$($l front) || assert_fail
+        v=$($e value) || assert_fail
+        [ "${v}" = 10 ] || assert_fail
+
+        e=$($l back) || assert_fail
+        v=$($e value) || assert_fail
+        [ "${v}" = 3 ] || assert_fail
+}
+readonly -f test_container_list_push_front

--- a/src/container/p.sh
+++ b/src/container/p.sh
@@ -8,3 +8,4 @@ if [ -n "${CONTAINER_PACKAGE:-}" ]; then return 0; fi
 readonly CONTAINER_PACKAGE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . ${CONTAINER_PACKAGE}/ring.sh
+. ${CONTAINER_PACKAGE}/list.sh


### PR DESCRIPTION
This PR introduces doubly linked list by mirroring https://pkg.go.dev/container/list.
Any error should trigger EC to be returned.