### PR TITLE
Add some time-getting functions and Pair collection

### DIFF
--- a/src/util/p.sh
+++ b/src/util/p.sh
@@ -18,3 +18,4 @@ readonly UTIL_PACKAGE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . ${UTIL_PACKAGE}/flags.sh
 . ${UTIL_PACKAGE}/complex.sh
 . ${UTIL_PACKAGE}/user.sh
+. ${UTIL_PACKAGE}/pair.sh

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# https://github.com/EngineeringSoftware/gobash/blob/main/LICENSE
+#
+# Pair collection.
+
+if [ -n "${PAIR_MOD:-}" ]; then return 0; fi
+readonly PAIR_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+. ${PAIR_MOD}/../lang/p.sh
+. ${PAIR_MOD}/math.sh
+
+# ----------
+# Functions.
+
+function Pair() {
+    # Pair collection.
+    local ctx; is_ctx "${1}" && ctx="${1}" && shift
+    [ $# -lt 0 ] && { ctx_wn $ctx; return $EC; }
+    shift 0 || { ctx_wn $ctx; return $EC; }
+
+    local pr=$(make_ $ctx "${FUNCNAME}") || \
+        { ctx_w "cannot make ${FUNCNAME}"; return $EC; }
+
+    if [ $# -eq 2 ] 
+    then
+        pr=$(make_ $ctx \
+            "${FUNCNAME}" \
+            "first" "${1}" \
+            "second" "${2}")
+    fi;
+
+    echo "${pr}"
+}

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -36,6 +36,26 @@ function Pair() {
     echo "${pr}"
 }
 
+function Pair_swap() {
+    # Swap two pairs. 
+    # E.g. p1{1, 2} p2{A, B}
+    # $p1 swap "$p2" cause p1{A, B} p2{1, 2}
+
+    local ctx; is_ctx "${1}" && ctx="${1}" && shift
+    [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
+
+    local pr1="${1}"
+    local pr2="${2}"
+
+    local tmp="$($pr1 first)"
+    $pr1 first "$($pr2 first)" 
+    $pr2 first "$tmp"
+
+    tmp="$($pr1 second)"
+    $pr1 second "$($pr2 second)" 
+    $pr2 second "$tmp"
+}
+
 function Pair_swap_args() {
     # Swap two elements in the pair.
     local ctx; is_ctx "${1}" && ctx="${1}" && shift

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -36,13 +36,17 @@ function Pair() {
     echo "${pr}"
 }
 
-function Pair_swap() {
+function Pair_swap_args() {
     # Swap two elements in the pair.
     local ctx; is_ctx "${1}" && ctx="${1}" && shift
     [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
 
     local pr="${1}"
-    local temp=$($pr first);
-    $pr first $($pr second);
-    $pr second $temp;
+
+    if [[ ! -z $($pr first) ]] && [[ ! -z $($pr second) ]];
+    then
+        local tmp=$($pr first);
+        $pr first $($pr second);
+        $pr second $tmp;
+    fi;
 }

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -22,13 +22,16 @@ function Pair() {
     local pr=$(make_ $ctx "${FUNCNAME}") || \
         { ctx_w "cannot make ${FUNCNAME}"; return $EC; }
 
-    if [ $# -eq 2 ] 
-    then
-        pr=$(make_ $ctx \
-            "${FUNCNAME}" \
-            "first" "${1}" \
-            "second" "${2}")
-    fi;
+    pr=$(make_ $ctx \
+        "${FUNCNAME}" \
+        "first" "${NULL}" \
+        "second" "${NULL}")
 
+    if [ ! -z "${1}" ]; then
+        $pr first "${1}"
+    fi;
+    if [ ! -z "${2}" ]; then
+        $pr second "${2}"
+    fi;
     echo "${pr}"
 }

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -35,3 +35,14 @@ function Pair() {
     fi;
     echo "${pr}"
 }
+
+function Pair_swap() {
+    # Swap two elements in the pair.
+    local ctx; is_ctx "${1}" && ctx="${1}" && shift
+    [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
+
+    local pr="${1}"
+    local temp=$($pr first);
+    $pr first $($pr second);
+    $pr second $temp;
+}

--- a/src/util/pair_test.sh
+++ b/src/util/pair_test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# https://github.com/EngineeringSoftware/gobash/blob/main/LICENSE
+#
+# Unit tests for the pair module.
+
+if [ -n "${PAIR_TEST_MOD:-}" ]; then return 0; fi
+readonly PAIR_TEST_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+. ${PAIR_TEST_MOD}/pair.sh
+. ${PAIR_TEST_MOD}/../testing/bunit.sh
+
+
+# ----------
+# Functions.
+
+function test_pair() {
+    local pr
+    pr=$(Pair) || \
+                assert_fail
+}
+readonly -f test_pair
+
+function test_pair_uninit() {
+    local pr
+    pr=$(Pair) || \
+                assert_fail
+    
+    assert_eq "$($pr first)" "${NULL}"
+    assert_eq "$($pr second)" "${NULL}"
+}
+readonly -f test_pair_uninit
+
+function test_pair_init() {
+    local pr
+    pr=$(Pair 1 2) || \
+                assert_fail
+    
+    assert_eq "$($pr first)" "1"
+    assert_eq "$($pr second)" "2"
+}
+readonly -f test_pair_init
+
+function test_pair_set() {
+    local pr
+    pr=$(Pair) || \
+                assert_fail
+    $pr first 1
+    assert_eq "$($pr first)" "1"
+    assert_eq "$($pr second)" "${NULL}"
+
+    $pr second 2
+    assert_eq "$($pr first)" "1"
+    assert_eq "$($pr second)" "2"
+}
+readonly -f test_pair_set
+
+function test_pair_swap() {
+    local pr1
+    local pr2
+    pr1=$(Pair 1 2) || \
+                assert_fail
+    pr2=$(Pair A B) || \
+                assert_fail
+    
+    $pr1 swap "$pr2"
+    assert_eq "$($pr1 first)" "A"
+    assert_eq "$($pr1 second)" "B"
+    assert_eq "$($pr2 first)" "1"
+    assert_eq "$($pr2 second)" "3"
+}
+readonly -f test_pair_swap
+
+function test_pair_swap_args() {
+    local pr
+    pr=$(Pair A B) || \
+                assert_fail
+    
+    $pr swap_args
+    assert_eq "$($pr first)" "B"
+    assert_eq "$($pr second)" "A"
+}
+readonly -f test_pair_swap_args

--- a/src/util/time.sh
+++ b/src/util/time.sh
@@ -27,13 +27,31 @@ function time_now_millis() {
         fi
 }
 
-function time_now_day() {
-        # Current day (as a number: 1-Mon, ... 7-Sun).
+function time_now_week_day() {
+        # Current day of the week (as a number: 1-Mon, ... 7-Sun).
         local ctx; is_ctx "${1}" && ctx="${1}" && shift
         [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
         shift 0 || { ctx_wn $ctx; return $EC; }
 
         $X_DATE +%u
+}
+
+function time_now_week_day_str() {
+        # Current day of the week (as a string: Monday, ... Sunday).
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
+        $X_DATE +%A
+}
+
+function time_now_month_day() {
+        # Current day of the month.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
+        $X_DATE +%e
 }
 
 function time_now_year() {
@@ -52,6 +70,15 @@ function time_now_month() {
         shift 0 || { ctx_wn $ctx; return $EC; }
 
         $X_DATE +%m
+}
+
+function time_now_month_str() {
+        # Current month (as a full string, e.g., January).
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
+        $X_DATE +%B
 }
 
 function time_now_iso8601() {

--- a/src/util/time_test.sh
+++ b/src/util/time_test.sh
@@ -49,14 +49,14 @@ function test_time_now_week_day_str() {
 }
 readonly -f test_time_now_week_day_str
 
-function time_now_month_day() {
+function test_time_now_month_day() {
         local day
         day=$(time_now_week_day) || \
                 assert_fail
         assert_gt "${day}" 0
         assert_lt "${day}" 32
 }
-readonly -f time_now_month_day
+readonly -f test_time_now_month_day
 
 function test_time_now_year() {
         local year

--- a/src/util/time_test.sh
+++ b/src/util/time_test.sh
@@ -51,7 +51,7 @@ readonly -f test_time_now_week_day_str
 
 function test_time_now_month_day() {
         local day
-        day=$(time_now_week_day) || \
+        day=$(time_now_month_day) || \
                 assert_fail
         assert_gt "${day}" 0
         assert_lt "${day}" 32

--- a/src/util/time_test.sh
+++ b/src/util/time_test.sh
@@ -22,14 +22,41 @@ function test_now_millis() {
 }
 readonly -f test_now_millis
 
-function test_time_now_day() {
+function test_time_now_week_day() {
         local day
-        day=$(time_now_day) || \
+        day=$(time_now_week_day) || \
                 assert_fail
         assert_gt "${day}" 0
         assert_lt "${day}" 8
 }
-readonly -f test_time_now_day
+readonly -f test_time_now_week_day
+
+function test_time_now_week_day_str() {
+        local day
+        day=$(time_now_week_day_str) || \
+                assert_fail
+
+        case "${day}" in
+        "Monday"|"monday") ;;
+        "Tuesday"|"tuesday") ;;
+        "Wednesday"|"wednesday") ;;
+        "Thursday"|"thursday") ;;
+        "Friday"|"friday") ;;
+        "Saturday"|"saturday") ;;
+        "Sunday"|"sunday") ;;
+        *) assert_fail "non-existing day of the week";;
+        esac
+}
+readonly -f test_time_now_week_day_str
+
+function time_now_month_day() {
+        local day
+        day=$(time_now_week_day) || \
+                assert_fail
+        assert_gt "${day}" 0
+        assert_lt "${day}" 32
+}
+readonly -f time_now_month_day
 
 function test_time_now_year() {
         local year
@@ -46,6 +73,29 @@ function test_time_now_month() {
         assert_eq "$($X_DATE +%m)" "${month}"
 }
 readonly -f test_time_now_month
+
+function test_time_now_month_str() {
+        local month
+        month=$(time_now_month_str) || \
+                assert_fail
+                
+        case "${month}" in
+        "Jan"|"January") ;;
+        "Feb"|"February") ;;
+        "Mar"|"March") ;;
+        "Apr"|"April") ;;
+        "May") ;;
+        "Jun"|"June") ;;
+        "Jul"|"July") ;;
+        "Aug"|"August") ;;
+        "Sep"|"September") ;;
+        "Oct"|"October") ;;
+        "Nov"|"November") ;;
+        "Dec"|"December") ;;
+        *) assert_fail "non-existent month";;
+        esac
+}
+readonly -f test_time_now_month_str
 
 function test_time_duration() {
         function _f() {


### PR DESCRIPTION
# Time module
Change the name of [`time_now_day`](https://github.com/EngineeringSoftware/gobash/blob/c86905e1a66b4a09eab8ed695f074aed73b76752/src/util/time.sh#L30) function to [`time_now_week_day`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time.sh#L30) with corresponding comment and [`test`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time_test.sh#L25).

Add some time-getting functions: 
- [`time_now_week_day_str`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time.sh#L39) : get day of the week name as string
- [`time_now_month_day`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time.sh#L48C32-L48C32) : get current day of the month
- [`time_now_month_str`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time.sh#L75) : get month name as string

with corresponding tests:
- [`test_time_now_week_day_str`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time_test.sh#L34)
- [`test_time_now_month_day`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time_test.sh#L52)
- [`test_time_now_month_str`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/time_test.sh#L77C10-L77C33)

# Pair module
Add new [`Pair module`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/pair.sh) with:
- [`Pair`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/pair.sh#L16) : collection with "first" and "second" element, as is common in some programming languages, like [C++](https://en.cppreference.com/w/cpp/utility/pair). Pretty useful, as variation of tuple.
- [`Pair_swap`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/pair.sh#L39) : swapping of two pair. E.g. if we have two pairs: `p1 {A, B}` and `p2 {1, 2}`, then after `$p1 swap "$p2"` we will have `p1 {1, 2}` and `p2 {A, B}` respectively.
- [`Pair_swap_args`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/pair.sh#L59) : method to swap fields in existing pair. E.g. if we have pair `p1 {A, B}`, then after `$p1 swap_args` we will have `p1 {B, A}`  

with corresponding [`unit tests`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/pair_test.sh)
and an addition to the [`package`](https://github.com/IvanGrigorik/gobash/blob/6a15a8057bd77083c00b66a3721f4e80f34d5ab8/src/util/p.sh#L21)