### PR TITLE
Add some time-getting functions

### DIFF
--- a/src/util/time.sh
+++ b/src/util/time.sh
@@ -27,13 +27,31 @@ function time_now_millis() {
         fi
 }
 
-function time_now_day() {
-        # Current day (as a number: 1-Mon, ... 7-Sun).
+function time_now_week_day() {
+        # Current day of the week (as a number: 1-Mon, ... 7-Sun).
         local ctx; is_ctx "${1}" && ctx="${1}" && shift
         [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
         shift 0 || { ctx_wn $ctx; return $EC; }
 
         $X_DATE +%u
+}
+
+function time_now_week_day_str() {
+        # Current day of the week (as a string: Monday, ... Sunday).
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
+        $X_DATE +%A
+}
+
+function time_now_month_day() {
+        # Current day of the month.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
+        $X_DATE +%e
 }
 
 function time_now_year() {
@@ -52,6 +70,15 @@ function time_now_month() {
         shift 0 || { ctx_wn $ctx; return $EC; }
 
         $X_DATE +%m
+}
+
+function time_now_month_str() {
+        # Current month (as a full string, e.g., January).
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
+
+        $X_DATE +%B
 }
 
 function time_now_iso8601() {

--- a/src/util/time.sh
+++ b/src/util/time.sh
@@ -27,7 +27,7 @@ function time_now_millis() {
         fi
 }
 
-function time_now_week_day() {
+function time_now_day_of_week() {
         # Current day of the week (as a number: 1-Mon, ... 7-Sun).
         local ctx; is_ctx "${1}" && ctx="${1}" && shift
         [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
@@ -36,7 +36,7 @@ function time_now_week_day() {
         $X_DATE +%u
 }
 
-function time_now_week_day_str() {
+function time_now_day_of_week_str() {
         # Current day of the week (as a string: Monday, ... Sunday).
         local ctx; is_ctx "${1}" && ctx="${1}" && shift
         [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }
@@ -45,7 +45,7 @@ function time_now_week_day_str() {
         $X_DATE +%A
 }
 
-function time_now_month_day() {
+function time_now_day_of_month() {
         # Current day of the month.
         local ctx; is_ctx "${1}" && ctx="${1}" && shift
         [ $# -ne 0 ] && { ctx_wn $ctx; return $EC; }

--- a/src/util/time_test.sh
+++ b/src/util/time_test.sh
@@ -18,7 +18,9 @@ function test_now_millis() {
         local ms
         ms=$(time_now_millis) || \
                 assert_fail
-        assert_ge "${ms}" 1689708545316
+        
+        [ "${ms}" -le 1689708545316 ] && assert_fail
+        return 0
 }
 readonly -f test_now_millis
 
@@ -26,8 +28,10 @@ function test_time_now_day_of_week() {
         local day
         day=$(time_now_day_of_week) || \
                 assert_fail
-        assert_gt "${day}" 0
-        assert_lt "${day}" 8
+
+        [ "${day}" -lt 0 ] && assert_fail
+        [ "${day}" -gt 8 ] && assert_fail
+        return 0
 }
 readonly -f test_time_now_day_of_week
 
@@ -53,8 +57,10 @@ function test_time_now_day_of_month() {
         local day
         day=$(time_now_day_of_month) || \
                 assert_fail
-        assert_gt "${day}" 0
-        assert_lt "${day}" 32
+
+        [ "${day}" -lt 0 ] && assert_fail
+        [ "${day}" -gt 32 ] && assert_fail
+        return 0
 }
 readonly -f test_time_now_day_of_month
 
@@ -62,7 +68,9 @@ function test_time_now_year() {
         local year
         year=$(time_now_year) || \
                 assert_fail
-        assert_eq "$($X_DATE +%Y)" "${year}"
+        
+        [ "$($X_DATE +%Y)" != "${year}" ] && assert_fail "$($X_DATE +%Y) not equal to ${year}"
+        return 0
 }
 readonly -f test_time_now_year
 
@@ -70,7 +78,9 @@ function test_time_now_month() {
         local month
         month=$(time_now_month) || \
                 assert_fail
-        assert_eq "$($X_DATE +%m)" "${month}"
+
+        [ "$($X_DATE +%m)" != "${month}" ] && assert_fail "$($X_DATE +%Y) not equal to ${year}"
+        return 0
 }
 readonly -f test_time_now_month
 
@@ -104,7 +114,9 @@ function test_time_duration() {
 
         local ec=0
         time_duration_w "ABC" _f > /dev/null || ec=$?
-        assert_eq 22 ${ec}
+        
+        [ ${ec} -ne 22 ] && assert_fail
+        return 0
 }
 readonly -f test_time_duration
 
@@ -112,7 +124,9 @@ function test_time_millis_to_seconds() {
         local secs
         secs=$(time_millis_to_seconds 2000) || \
                 assert_fail
-        assert_eq 2 "${secs}"
+        
+        [ ${secs} -ne 2 ] && assert_fail
+        return 0
 }
 readonly -f test_time_millis_to_seconds
 
@@ -120,12 +134,14 @@ function test_time_millis_to_date() {
         local actual
         actual=$(time_millis_to_date "1670357961396") || \
                 assert_fail
-        assert_eq "2022-12-06" "${actual% *}"
+
+        [ "2022-12-06" != "${actual% *}" ] && assert_fail
+        return 0
 }
 readonly -f test_time_millis_to_date
 
 function test_time_num_to_month() {
-        assert_eq "Mar" $(time_num_to_month 3)
+        [ "Mar" != "$(time_num_to_month 3)" ] && assert_fail
 
         local ctx
 
@@ -134,11 +150,12 @@ function test_time_num_to_month() {
                 assert_fail
         ctx_show $ctx | grep 'incorrect month number' || \
                 assert_fail
+        return 0
 }
 readonly -f test_time_num_to_month
 
 function test_time_month_to_num() {
-        assert_eq 3 $(time_month_to_num "Mar")
+        [ 3 -ne  $(time_month_to_num "Mar") ] && assert_fail
 
         local ctx
 

--- a/src/util/time_test.sh
+++ b/src/util/time_test.sh
@@ -22,14 +22,41 @@ function test_now_millis() {
 }
 readonly -f test_now_millis
 
-function test_time_now_day() {
+function test_time_now_week_day() {
         local day
-        day=$(time_now_day) || \
+        day=$(time_now_week_day) || \
                 assert_fail
         assert_gt "${day}" 0
         assert_lt "${day}" 8
 }
-readonly -f test_time_now_day
+readonly -f test_time_now_week_day
+
+function test_time_now_week_day_str() {
+        local day
+        day=$(time_now_week_day_str) || \
+                assert_fail
+
+        case "${day}" in
+        "Monday"|"monday") ;;
+        "Tuesday"|"tuesday") ;;
+        "Wednesday"|"wednesday") ;;
+        "Thursday"|"thursday") ;;
+        "Friday"|"friday") ;;
+        "Saturday"|"saturday") ;;
+        "Sunday"|"sunday") ;;
+        *) assert_fail "non-existing day of the week";;
+        esac
+}
+readonly -f test_time_now_week_day_str
+
+function test_time_now_month_day() {
+        local day
+        day=$(time_now_month_day) || \
+                assert_fail
+        assert_gt "${day}" 0
+        assert_lt "${day}" 32
+}
+readonly -f test_time_now_month_day
 
 function test_time_now_year() {
         local year
@@ -46,6 +73,29 @@ function test_time_now_month() {
         assert_eq "$($X_DATE +%m)" "${month}"
 }
 readonly -f test_time_now_month
+
+function test_time_now_month_str() {
+        local month
+        month=$(time_now_month_str) || \
+                assert_fail
+                
+        case "${month}" in
+        "Jan"|"January") ;;
+        "Feb"|"February") ;;
+        "Mar"|"March") ;;
+        "Apr"|"April") ;;
+        "May") ;;
+        "Jun"|"June") ;;
+        "Jul"|"July") ;;
+        "Aug"|"August") ;;
+        "Sep"|"September") ;;
+        "Oct"|"October") ;;
+        "Nov"|"November") ;;
+        "Dec"|"December") ;;
+        *) assert_fail "non-existent month";;
+        esac
+}
+readonly -f test_time_now_month_str
 
 function test_time_duration() {
         function _f() {

--- a/src/util/time_test.sh
+++ b/src/util/time_test.sh
@@ -22,18 +22,18 @@ function test_now_millis() {
 }
 readonly -f test_now_millis
 
-function test_time_now_week_day() {
+function test_time_now_day_of_week() {
         local day
-        day=$(time_now_week_day) || \
+        day=$(time_now_day_of_week) || \
                 assert_fail
         assert_gt "${day}" 0
         assert_lt "${day}" 8
 }
-readonly -f test_time_now_week_day
+readonly -f test_time_now_day_of_week
 
-function test_time_now_week_day_str() {
+function test_time_now_day_of_week_str() {
         local day
-        day=$(time_now_week_day_str) || \
+        day=$(time_now_day_of_week_str) || \
                 assert_fail
 
         case "${day}" in
@@ -47,16 +47,16 @@ function test_time_now_week_day_str() {
         *) assert_fail "non-existing day of the week";;
         esac
 }
-readonly -f test_time_now_week_day_str
+readonly -f test_time_now_day_of_week_str
 
-function test_time_now_month_day() {
+function test_time_now_day_of_month() {
         local day
-        day=$(time_now_month_day) || \
+        day=$(time_now_day_of_month) || \
                 assert_fail
         assert_gt "${day}" 0
         assert_lt "${day}" 32
 }
-readonly -f test_time_now_month_day
+readonly -f test_time_now_day_of_month
 
 function test_time_now_year() {
         local year


### PR DESCRIPTION
# Time module
Change the name of [`time_now_day`](https://github.com/EngineeringSoftware/gobash/blob/c86905e1a66b4a09eab8ed695f074aed73b76752/src/util/time.sh#L30) function to [`time_now_day_of_week`](https://github.com/IvanGrigorik/gobash/blob/4a8692a0599ceeae0af1d05f1d1b4a11e83e7b89/src/util/time.sh#L30) with corresponding comment and [`test`](https://github.com/IvanGrigorik/gobash/blob/e9945ba9dcd57307806a32b23b07b3c56193ae02/src/util/time_test.sh#L25).

Add some time-getting functions: 
- [`time_now_day_of_week_str`](https://github.com/IvanGrigorik/gobash/blob/4a8692a0599ceeae0af1d05f1d1b4a11e83e7b89/src/util/time.sh#L39) : get day of the week name as string
- [`time_now_day_of_month`](https://github.com/IvanGrigorik/gobash/blob/4a8692a0599ceeae0af1d05f1d1b4a11e83e7b89/src/util/time.sh#L48) : get current day of the month
- [`time_now_month_str`](https://github.com/IvanGrigorik/gobash/blob/4a8692a0599ceeae0af1d05f1d1b4a11e83e7b89/src/util/time.sh#L75) : get month name as string

with corresponding tests:
- [`test_time_now_day_of_week_str`](https://github.com/IvanGrigorik/gobash/blob/e9945ba9dcd57307806a32b23b07b3c56193ae02/src/util/time_test.sh#L34)
- [`test_time_now_day_of_month`](https://github.com/IvanGrigorik/gobash/blob/e9945ba9dcd57307806a32b23b07b3c56193ae02/src/util/time_test.sh#L52)
- [`test_time_now_month_str`](https://github.com/IvanGrigorik/gobash/blob/e9945ba9dcd57307806a32b23b07b3c56193ae02/src/util/time_test.sh#L77)