### PR TITLE
Pair module

### DIFF
--- a/src/util/p.sh
+++ b/src/util/p.sh
@@ -18,3 +18,4 @@ readonly UTIL_PACKAGE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . ${UTIL_PACKAGE}/flags.sh
 . ${UTIL_PACKAGE}/complex.sh
 . ${UTIL_PACKAGE}/user.sh
+. ${UTIL_PACKAGE}/pair.sh

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# https://github.com/EngineeringSoftware/gobash/blob/main/LICENSE
+#
+# Pair collection.
+
+if [ -n "${PAIR_MOD:-}" ]; then return 0; fi
+readonly PAIR_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+. ${PAIR_MOD}/../lang/p.sh
+. ${PAIR_MOD}/math.sh
+
+# ----------
+# Functions.
+
+function Pair() {
+    # Pair collection.
+    local ctx; is_ctx "${1}" && ctx="${1}" && shift
+    [ $# -lt 0 ] && { ctx_wn $ctx; return $EC; }
+    shift 0 || { ctx_wn $ctx; return $EC; }
+
+    local pr=$(make_ $ctx "${FUNCNAME}") || \
+        { ctx_w "cannot make ${FUNCNAME}"; return $EC; }
+
+    pr=$(make_ $ctx \
+        "${FUNCNAME}" \
+        "first" "${NULL}" \
+        "second" "${NULL}")
+
+    if [ ! -z "${1}" ]; then
+        $pr first "${1}"
+    fi;
+    if [ ! -z "${2}" ]; then
+        $pr second "${2}"
+    fi;
+    echo "${pr}"
+}
+
+function Pair_swap() {
+    # Swap two pairs. 
+    # E.g. p1{1, 2} p2{A, B}
+    # $p1 swap "$p2" cause p1{A, B} p2{1, 2}
+
+    local ctx; is_ctx "${1}" && ctx="${1}" && shift
+    [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
+
+    local pr1="${1}"
+    local pr2="${2}"
+
+    local tmp="$($pr1 first)"
+    $pr1 first "$($pr2 first)" 
+    $pr2 first "$tmp"
+
+    tmp="$($pr1 second)"
+    $pr1 second "$($pr2 second)" 
+    $pr2 second "$tmp"
+}
+
+function Pair_swap_args() {
+    # Swap two elements in the pair.
+    local ctx; is_ctx "${1}" && ctx="${1}" && shift
+    [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
+
+    local pr="${1}"
+
+    if [[ ! -z $($pr first) ]] && [[ ! -z $($pr second) ]];
+    then
+        local tmp=$($pr first);
+        $pr first $($pr second);
+        $pr second $tmp;
+    fi;
+}

--- a/src/util/pair.sh
+++ b/src/util/pair.sh
@@ -14,59 +14,59 @@ readonly PAIR_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # Functions.
 
 function Pair() {
-    # Pair collection.
-    local ctx; is_ctx "${1}" && ctx="${1}" && shift
-    [ $# -lt 0 ] && { ctx_wn $ctx; return $EC; }
-    shift 0 || { ctx_wn $ctx; return $EC; }
+        # Pair collection.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -lt 0 ] && { ctx_wn $ctx; return $EC; }
+        shift 0 || { ctx_wn $ctx; return $EC; }
 
-    local pr=$(make_ $ctx "${FUNCNAME}") || \
-        { ctx_w "cannot make ${FUNCNAME}"; return $EC; }
+        local pr=$(make_ $ctx "${FUNCNAME}") || \
+                { ctx_w "cannot make ${FUNCNAME}"; return $EC; }
 
-    pr=$(make_ $ctx \
-        "${FUNCNAME}" \
-        "first" "${NULL}" \
-        "second" "${NULL}")
+        pr=$(make_ $ctx \
+                "${FUNCNAME}" \
+                "first" "${NULL}" \
+                "second" "${NULL}")
 
-    if [ ! -z "${1}" ]; then
-        $pr first "${1}"
-    fi;
-    if [ ! -z "${2}" ]; then
-        $pr second "${2}"
-    fi;
-    echo "${pr}"
+        if [ ! -z "${1}" ]; then
+                $pr first "${1}"
+        fi;
+        if [ ! -z "${2}" ]; then
+                $pr second "${2}"
+        fi;
+        echo "${pr}"
 }
 
 function Pair_swap() {
-    # Swap two pairs. 
-    # E.g. p1{1, 2} p2{A, B}
-    # $p1 swap "$p2" cause p1{A, B} p2{1, 2}
+        # Swap two pairs. 
+        # E.g. p1{1, 2} p2{A, B}
+        # $p1 swap "$p2" cause p1{A, B} p2{1, 2}
 
-    local ctx; is_ctx "${1}" && ctx="${1}" && shift
-    [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 2 ] && { ctx_wn $ctx; return $EC; }
 
-    local pr1="${1}"
-    local pr2="${2}"
+        local pr1="${1}"
+        local pr2="${2}"
 
-    local tmp="$($pr1 first)"
-    $pr1 first "$($pr2 first)" 
-    $pr2 first "$tmp"
+        local tmp="$($pr1 first)"
+        $pr1 first "$($pr2 first)" 
+        $pr2 first "$tmp"
 
-    tmp="$($pr1 second)"
-    $pr1 second "$($pr2 second)" 
-    $pr2 second "$tmp"
+        tmp="$($pr1 second)"
+        $pr1 second "$($pr2 second)" 
+        $pr2 second "$tmp"
 }
 
 function Pair_swap_args() {
-    # Swap two elements in the pair.
-    local ctx; is_ctx "${1}" && ctx="${1}" && shift
-    [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
+        # Swap two elements in the pair.
+        local ctx; is_ctx "${1}" && ctx="${1}" && shift
+        [ $# -ne 1 ] && { ctx_wn $ctx; return $EC; }
 
-    local pr="${1}"
+        local pr="${1}"
 
-    if [[ ! -z $($pr first) ]] && [[ ! -z $($pr second) ]];
-    then
-        local tmp=$($pr first);
-        $pr first $($pr second);
-        $pr second $tmp;
-    fi;
+        if [[ ! -z $($pr first) ]] && [[ ! -z $($pr second) ]];
+        then
+                local tmp=$($pr first);
+                $pr first $($pr second);
+                $pr second $tmp;
+        fi;
 }

--- a/src/util/pair_test.sh
+++ b/src/util/pair_test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# https://github.com/EngineeringSoftware/gobash/blob/main/LICENSE
+#
+# Unit tests for the pair module.
+
+if [ -n "${PAIR_TEST_MOD:-}" ]; then return 0; fi
+readonly PAIR_TEST_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+. ${PAIR_TEST_MOD}/pair.sh
+. ${PAIR_TEST_MOD}/../testing/bunit.sh
+
+
+# ----------
+# Functions.
+
+function test_pair() {
+    local pr
+    pr=$(Pair) || \
+                assert_fail
+}
+readonly -f test_pair
+
+function test_pair_uninit() {
+    local pr
+    pr=$(Pair) || \
+                assert_fail
+    
+    assert_eq "$($pr first)" "${NULL}"
+    assert_eq "$($pr second)" "${NULL}"
+}
+readonly -f test_pair_uninit
+
+function test_pair_init() {
+    local pr
+    pr=$(Pair 1 2) || \
+                assert_fail
+    
+    assert_eq "$($pr first)" "1"
+    assert_eq "$($pr second)" "2"
+}
+readonly -f test_pair_init
+
+function test_pair_set() {
+    local pr
+    pr=$(Pair) || \
+                assert_fail
+    $pr first 1
+    assert_eq "$($pr first)" "1"
+    assert_eq "$($pr second)" "${NULL}"
+
+    $pr second 2
+    assert_eq "$($pr first)" "1"
+    assert_eq "$($pr second)" "2"
+}
+readonly -f test_pair_set
+
+function test_pair_swap() {
+    local pr1
+    local pr2
+    pr1=$(Pair 1 2) || \
+                assert_fail
+    pr2=$(Pair A B) || \
+                assert_fail
+    
+    $pr1 swap "$pr2"
+    assert_eq "$($pr1 first)" "A"
+    assert_eq "$($pr1 second)" "B"
+    assert_eq "$($pr2 first)" "1"
+    assert_eq "$($pr2 second)" "3"
+}
+readonly -f test_pair_swap
+
+function test_pair_swap_args() {
+    local pr
+    pr=$(Pair A B) || \
+                assert_fail
+    
+    $pr swap_args
+    assert_eq "$($pr first)" "B"
+    assert_eq "$($pr second)" "A"
+}
+readonly -f test_pair_swap_args

--- a/src/util/pair_test.sh
+++ b/src/util/pair_test.sh
@@ -15,69 +15,69 @@ readonly PAIR_TEST_MOD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # Functions.
 
 function test_pair() {
-    local pr
-    pr=$(Pair) || \
+        local pr
+        pr=$(Pair) || \
                 assert_fail
 }
 readonly -f test_pair
 
 function test_pair_uninit() {
-    local pr
-    pr=$(Pair) || \
+        local pr
+        pr=$(Pair) || \
                 assert_fail
     
-    assert_eq "$($pr first)" "${NULL}"
-    assert_eq "$($pr second)" "${NULL}"
+        assert_eq "$($pr first)" "${NULL}"
+        assert_eq "$($pr second)" "${NULL}"
 }
 readonly -f test_pair_uninit
 
 function test_pair_init() {
-    local pr
-    pr=$(Pair 1 2) || \
+        local pr
+        pr=$(Pair 1 2) || \
                 assert_fail
     
-    assert_eq "$($pr first)" "1"
-    assert_eq "$($pr second)" "2"
+        assert_eq "$($pr first)" "1"
+        assert_eq "$($pr second)" "2"
 }
 readonly -f test_pair_init
 
 function test_pair_set() {
-    local pr
-    pr=$(Pair) || \
+        local pr
+        pr=$(Pair) || \
                 assert_fail
-    $pr first 1
-    assert_eq "$($pr first)" "1"
-    assert_eq "$($pr second)" "${NULL}"
+        $pr first 1
+        assert_eq "$($pr first)" "1"
+        assert_eq "$($pr second)" "${NULL}"
 
-    $pr second 2
-    assert_eq "$($pr first)" "1"
-    assert_eq "$($pr second)" "2"
+        $pr second 2
+        assert_eq "$($pr first)" "1"
+        assert_eq "$($pr second)" "2"
 }
 readonly -f test_pair_set
 
 function test_pair_swap() {
-    local pr1
-    local pr2
-    pr1=$(Pair 1 2) || \
+        local pr1
+        local pr2
+        pr1=$(Pair 1 2) || \
                 assert_fail
-    pr2=$(Pair A B) || \
+        pr2=$(Pair A B) || \
                 assert_fail
-    
-    $pr1 swap "$pr2"
-    assert_eq "$($pr1 first)" "A"
-    assert_eq "$($pr1 second)" "B"
-    assert_eq "$($pr2 first)" "1"
-    assert_eq "$($pr2 second)" "3"
+
+        $pr1 swap "$pr2"
+        assert_eq "$($pr1 first)" "A"
+        assert_eq "$($pr1 second)" "B"
+        assert_eq "$($pr2 first)" "1"
+        assert_eq "$($pr2 second)" "3"
 }
 readonly -f test_pair_swap
 
 function test_pair_swap_args() {
-    local pr
-    pr=$(Pair A B) || \
+        local pr
+        pr=$(Pair A B) || \
                 assert_fail
-    
-    $pr swap_args
-    assert_eq "$($pr first)" "B"
-    assert_eq "$($pr second)" "A"
+
+        $pr swap_args
+        assert_eq "$($pr first)" "B"
+        assert_eq "$($pr second)" "A"
 }
 readonly -f test_pair_swap_args


### PR DESCRIPTION
# Pair module
Add new [`Pair module`](https://github.com/IvanGrigorik/gobash/blob/pair_module/src/util/pair.sh) with:
- [`Pair`](https://github.com/IvanGrigorik/gobash/blob/pair_module/src/util/pair.sh#L16) : collection with "first" and "second" element, as is common in some programming languages, like [C++](https://en.cppreference.com/w/cpp/utility/pair). Pretty useful, as variation of tuple.
- [`Pair_swap`](https://github.com/IvanGrigorik/gobash/blob/pair_module/src/util/pair.sh#L39) : swapping of two pair. E.g. if we have two pairs: `p1 {A, B}` and `p2 {1, 2}`, then after `$p1 swap "$p2"` we will have `p1 {1, 2}` and `p2 {A, B}` respectively.
- [`Pair_swap_args`](https://github.com/IvanGrigorik/gobash/blob/pair_module/src/util/pair.sh#L59) : method to swap fields in existing pair. E.g. if we have pair `p1 {A, B}`, then after `$p1 swap_args` we will have `p1 {B, A}`  

with corresponding [`unit tests`](https://github.com/IvanGrigorik/gobash/blob/pair_module/src/util/pair_test.sh)
and an addition to the [`package`](https://github.com/IvanGrigorik/gobash/blob/pair_module/src/util/p.sh#L21)